### PR TITLE
fix[#34] patch get_server_ip return always 0.0.0.0

### DIFF
--- a/src/library.c
+++ b/src/library.c
@@ -59,9 +59,9 @@ static void exclude_others(void *adr, size_t s, enum lock_type lock_type, void (
 	}
 }
 
-void *Init_DSM(size_t size, int port)
+void *Init_DSM(size_t size, const char* interface, int port)
 {
-	start_server(port);
+	start_server(port, interface);
 	set_all_handlers();
 	
 	// init internal data
@@ -88,11 +88,11 @@ void free_DSM()
 	munmap(dsm, nb_pages * PAGE_SIZE);
 }
 
-void *join_DSM(const char *host, int connect_port, int server_port)
+void *join_DSM(const char *host, int connect_port, const char *interface, int server_port)
 {
 	size_t msg_sz = sizeof(struct message);
 
-	start_server(server_port);
+	start_server(server_port, interface);
 	set_all_handlers();
 	
 	if (init_my_node_id()) return NULL;

--- a/src/library.h
+++ b/src/library.h
@@ -16,6 +16,8 @@
 #include "utils/logger.h"
 #include "INFO_DSM_message.h"
 
+#define LOCALHOST "127.0.0.1"
+
 /* 
     if you want to setup the debug mode, you have to ' export LIBRARY_DEBUG '
     to disable it just 'unset LIBRARY_DEBUG'
@@ -36,9 +38,10 @@
 /// This function allocates and initializes a distributed shared memory region for the initial node.
 ///
 /// @param size The size (in bytes) of the shared memory to initialize.
+/// @param interface The interface for binding socket, it ensure that the node have only one id.
 /// @param port The port you use to communicate
 /// @return A pointer to the allocated shared memory region on success, NULL otherwise.
-void *Init_DSM(size_t size, int port);
+void *Init_DSM(size_t size, const char* interface, int port);
 
 void free_DSM(void);
 
@@ -50,9 +53,10 @@ void free_DSM(void);
 ///
 /// @param host The hostname or IP address of the existing node to connect to.
 /// @param connect_port The port of the existing node to connect to.
+/// @param interface The interface for binding socket, it ensure that the node have only one id.
 /// @param server_port The port you listen to add a new node
 /// @return A pointer to the shared memory region.
-void *join_DSM(const char *host, int connect_port, int server_port);
+void *join_DSM(const char *host, int connect_port, const char*interface, int server_port);
 
 
 /// @brief Requests a read lock for the specified memory region.

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -28,57 +28,43 @@ void * server_thread(void * arg)
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 
 	listen_sock = -1;
-	struct addrinfo hints, *res, *p;
-	int rv;
 	char listen_port[6]; // Listening port (as string)
+	const char *interface = (char *)arg;
 
-	snprintf(listen_port, sizeof(listen_port), "%d", server_port);
+	struct sockaddr_in serveraddr = { 0 };
+	serveraddr.sin_family = AF_INET;
+	serveraddr.sin_port = htons(server_port);
 
-	// Set up hints for getaddrinfo for a passive (server) socket.
-	memset(&hints, 0, sizeof(hints));
-	hints.ai_family = AF_UNSPEC; // Allow IPv4 or IPv6
-	hints.ai_socktype = SOCK_STREAM; // TCP stream sockets
-	hints.ai_flags = AI_PASSIVE; // Use the local IP
-
-	if ((rv = getaddrinfo(NULL, listen_port, &hints, &res)) != 0) {
-		fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(rv));
+	listen_sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (listen_sock < 0) {
+		perror("socket");
 		return NULL;
 	}
 
-	// Loop through all results and bind to the first we can.
-	for (p = res; p != NULL; p = p->ai_next) {
-		listen_sock = socket(p->ai_family, p->ai_socktype,
-		                     p->ai_protocol);
-		if (listen_sock < 0) {
-			perror("socket");
-			continue;
-		}
-		// Enable address reuse.
-		int optval = 1;
-		if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR,
-		               &optval,
-		               sizeof(optval)) < 0) {
-			perror("setsockopt");
-			close(listen_sock);
-			continue;
-		}
-		if (bind(listen_sock, p->ai_addr, p->ai_addrlen) < 0) {
-			perror("bind");
-			close(listen_sock);
-			continue;
-		}
-		break; // Successfully bound.
-	}
-
-	if (p == NULL || listen_sock == -1) {
-		fprintf(
-			stderr,
-			"Failed to bind listening socket on port %s\n",
-			listen_port);
-		freeaddrinfo(res);
+	if (inet_pton(AF_INET, interface ? interface : "127.0.0.1",
+		      &serveraddr.sin_addr) <= 0) {
+		perror("inet_pton");
+		close(listen_sock);
 		return NULL;
 	}
-	freeaddrinfo(res);
+
+	char tmp_test[INET6_ADDRSTRLEN];
+	inet_ntop(AF_INET, &serveraddr.sin_addr, tmp_test, INET6_ADDRSTRLEN);
+
+	// Enable address reuse.
+	int optval = 1;
+	if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &optval,
+		       sizeof(optval)) < 0) {
+		perror("setsockopt");
+		close(listen_sock);
+		return NULL;
+	}
+	if (bind(listen_sock, (struct sockaddr *)&serveraddr,
+		 sizeof(serveraddr)) < 0) {
+		perror("bind");
+		close(listen_sock);
+		return NULL;
+	}
 
 	// Start listening for incoming connections.
 	if (listen(listen_sock, 5) < 0) {
@@ -166,7 +152,7 @@ void * server_thread(void * arg)
     return NULL;
 }
 
-void start_server(const int port)
+void start_server(const int port, const char* interface)
 {
 	LOG_NETWORK("Starting server on port %i", port);
 	server_port = port;
@@ -175,7 +161,7 @@ void start_server(const int port)
 	}
 
 	server_is_running = 1;
-	pthread_create(&server_thread_id, NULL, server_thread, NULL);
+	pthread_create(&server_thread_id, NULL, server_thread, (void *)interface);
 	// wait until the server is started
 	pthread_mutex_lock(&mutex);
 	pthread_cond_wait(&cond, &mutex);
@@ -210,29 +196,17 @@ int get_server_port()
 
 char * get_server_ip()
 {
+	struct sockaddr_in local_addr;
+	socklen_t addr_len = sizeof(local_addr);
+
+	if (getsockname(listen_sock, (struct sockaddr *)&local_addr,
+			&addr_len) == -1) {
+		perror("getsockname");
+		return NULL;
+	}
+
 	char *ip = malloc(INET6_ADDRSTRLEN);
-	if (ip == NULL) {
-		perror("malloc");
-		return NULL;
-	}
-
-	struct addrinfo hints, *res;
-	int rv;
-
-	memset(&hints, 0, sizeof(hints));
-	hints.ai_family = AF_UNSPEC;
-	hints.ai_socktype = SOCK_STREAM;
-
-	if ((rv = getaddrinfo("localhost", NULL, &hints, &res)) != 0) {
-		fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(rv));
-		free(ip);
-		return NULL;
-	}
-
-	struct sockaddr_in *addr = (struct sockaddr_in *)res->ai_addr;
-	inet_ntop(AF_INET, &addr->sin_addr, ip, INET6_ADDRSTRLEN);
-
-	freeaddrinfo(res);
+	inet_ntop(AF_INET, &local_addr.sin_addr, ip, INET6_ADDRSTRLEN);
 
 	return ip;
 }

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -49,9 +49,6 @@ void * server_thread(void * arg)
 		return NULL;
 	}
 
-	char tmp_test[INET6_ADDRSTRLEN];
-	inet_ntop(AF_INET, &serveraddr.sin_addr, tmp_test, INET6_ADDRSTRLEN);
-
 	// Enable address reuse.
 	int optval = 1;
 	if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &optval,

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -1,4 +1,5 @@
 #include "network.h"
+#include "library.h"
 #include <netinet/in.h>
 #include <string.h>
 
@@ -41,7 +42,7 @@ void * server_thread(void * arg)
 		return NULL;
 	}
 
-	if (inet_pton(AF_INET, interface ? interface : "127.0.0.1",
+	if (inet_pton(AF_INET, interface ? interface : LOCALHOST,
 		      &serveraddr.sin_addr) <= 0) {
 		perror("inet_pton");
 		close(listen_sock);

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -32,7 +32,7 @@
 /// @details Initializes the server and begins listening for incoming connections on the given port.
 ///          This function should be called before attempting to send or receive messages.
 /// @param port The port number on which the server will listen.
-/// @param interface The address on which the socket server will be bind, if NULL then 127.0.0.1 will be used.
+/// @param interface The address on which the socket server will be bind, if NULL then LOCALHOST will be used.
 void start_server(int port, const char* interface);
 
 /// @brief Stops the running server.

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -32,7 +32,8 @@
 /// @details Initializes the server and begins listening for incoming connections on the given port.
 ///          This function should be called before attempting to send or receive messages.
 /// @param port The port number on which the server will listen.
-void start_server(int port);
+/// @param interface The address on which the socket server will be bind, if NULL then 127.0.0.1 will be used.
+void start_server(int port, const char* interface);
 
 /// @brief Stops the running server.
 /// @details Gracefully stops the server by closing all connections and terminating the server thread.

--- a/test/core/data_transfer_test.cpp
+++ b/test/core/data_transfer_test.cpp
@@ -52,7 +52,7 @@ TEST(data_transfer, join_then_try_sync_a_page)
     int eq = 0;
     if (pid) {
         
-        Init_DSM(SIZE_DSM, init_port);
+        Init_DSM(SIZE_DSM, LOCALHOST, init_port);
 
         eq = check_page_owners_equality();
         ASSERT_EQ(eq, 1);
@@ -79,7 +79,7 @@ TEST(data_transfer, join_then_try_sync_a_page)
         // wait until INIT is setup
         sleep(1);
 
-        join_DSM(addr_init, init_port, joiner_port);
+        join_DSM(addr_init, init_port, LOCALHOST, joiner_port);
 
         ASSERT_EQ(nb_pages, nb_pages_);
 

--- a/test/library/init_func_test.cpp
+++ b/test/library/init_func_test.cpp
@@ -65,7 +65,7 @@ TEST(join_init_dsm, try_to_init_then_join_the_dsm)
     pid_t pid = fork();
     if (pid) {
         
-        Init_DSM(SIZE_DSM, init_port);
+        Init_DSM(SIZE_DSM, LOCALHOST, init_port);
 
         log_info("INIT :  dsm ready");
 
@@ -96,7 +96,7 @@ TEST(join_init_dsm, try_to_init_then_join_the_dsm)
         // wait until INIT is setup
         sleep(1);
 
-        join_DSM(addr_init, init_port, joiner_port);
+        join_DSM(addr_init, init_port, LOCALHOST, joiner_port);
 
         ASSERT_EQ(nb_pages, nb_pages_);
 

--- a/test/network/network_test.cpp
+++ b/test/network/network_test.cpp
@@ -30,7 +30,7 @@ TEST(network, basic_receive)
 {
 	init_logger(stderr);
 	counter = 0;
-	start_server(5555);
+	start_server(5555, NULL);
 
 	addHandler(1,NULL, callBack);
 
@@ -52,7 +52,7 @@ TEST(network, must_not_receive_if_message_number_is_different)
 {
 	init_logger(stderr);
 	counter = 0;
-	start_server(5555);
+	start_server(5555, NULL);
 
 	addHandler(1,NULL, callBack);
 
@@ -100,7 +100,7 @@ TEST(network, basic_receive2)
 {
 	init_logger(stderr);
 	counter = 0;
-	start_server(5555);
+	start_server(5555, NULL);
 
 	addHandler(2,NULL, callBack2);
 
@@ -141,7 +141,7 @@ TEST(network, wait_for_message)
 {
 	init_logger(stderr);
 	counter = 0;
-	start_server(5555);
+	start_server(5555, NULL);
 
 	sleep(1);
 


### PR DESCRIPTION
Add interface to bind the server socket to a specific network interface and ensure that a node have only one ip adresse